### PR TITLE
Knockback + bug fixes

### DIFF
--- a/Assets/PreFabs/EnviromentPieces/Moving Platform.prefab
+++ b/Assets/PreFabs/EnviromentPieces/Moving Platform.prefab
@@ -213,7 +213,7 @@ GameObject:
   - component: {fileID: 2023104293196848208}
   - component: {fileID: 5341037751945049968}
   - component: {fileID: 1163108842042760540}
-  m_Layer: 7
+  m_Layer: 0
   m_Name: PlayerMoveRegion
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -248,6 +248,26 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3554721410270378785, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -341,8 +361,20 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 50
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -480,6 +512,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 67a1254c1c2640042ab4e2344f094e15, type: 3}
+--- !u!114 &406320700 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7525053940169157166, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+  m_PrefabInstance: {fileID: 142971630}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &417234731
 GameObject:
   m_ObjectHideFlags: 0
@@ -909,6 +952,17 @@ Animator:
   m_CorrespondingSourceObject: {fileID: 1622175097124415811, guid: 9bc1dd99d5edf1b4db249918558d29ff, type: 3}
   m_PrefabInstance: {fileID: 1893879966}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &940089767 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 698243411030967027, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
+  m_PrefabInstance: {fileID: 142971630}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1017749038
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1447,6 +1501,14 @@ PrefabInstance:
       propertyPath: ScoreText
       value: 
       objectReference: {fileID: 142971632}
+    - target: {fileID: 3990704424520477542, guid: 5ee2ccecf6f22de438880794492fef30, type: 3}
+      propertyPath: BarFillImage
+      value: 
+      objectReference: {fileID: 940089767}
+    - target: {fileID: 3990704424520477542, guid: 5ee2ccecf6f22de438880794492fef30, type: 3}
+      propertyPath: MultiplierText
+      value: 
+      objectReference: {fileID: 406320700}
     - target: {fileID: 6989577316145350444, guid: 5ee2ccecf6f22de438880794492fef30, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/Scenes/TestingGyms/KnockbackTest.unity
+++ b/Assets/Scenes/TestingGyms/KnockbackTest.unity
@@ -137,7 +137,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &157493941
 Transform:
   m_ObjectHideFlags: 0
@@ -490,6 +490,91 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bfeaf1428ec6594e8041184c91e4bf1, type: 3}
+--- !u!1001 &877935293
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 578671847069664140, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3596868594772921216, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_Name
+      value: L5RRollingFruit
+      objectReference: {fileID: 0}
+    - target: {fileID: 3596868594772921216, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732012390135048172, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: _movesLeft
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7512414420570170046, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8200963162778218142, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fb888f2b1defec04ba75e55a62343e4e, type: 3}
 --- !u!1001 &1027200026
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -763,3 +848,4 @@ SceneRoots:
   - {fileID: 1027200026}
   - {fileID: 493741222}
   - {fileID: 157493941}
+  - {fileID: 877935293}

--- a/Assets/Scripts/PlayerScripts/PlayerBehaviour.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerBehaviour.cs
@@ -108,6 +108,8 @@ public class PlayerBehaviour : MonoBehaviour
         {
             MovePlayer();
         }
+
+        print(rb2d.velocity.y);
     }
 
     /// <summary>
@@ -170,7 +172,10 @@ public class PlayerBehaviour : MonoBehaviour
         var hit = Physics2D.BoxCast(hitbox.bounds.center, hitbox.bounds.size * .95f, 0, Vector2.down, 0.1f, ground);
         if (hit.collider != null)
         {
-            return hitbox.bounds.min.y > hit.collider.bounds.max.y;
+            // Bounds check: hamster is entirely above the surface it is interacting with (rather than within)
+            // Velocity check: hamster is not currently jumping (needed because there are some platforms you can
+            //                 stand inside of and should be able to jump inside of)
+            return (hitbox.bounds.min.y > hit.collider.bounds.max.y - 0.1f) || (Mathf.Abs(rb2d.velocity.y) < 0.01f);
         }
         return false;
     }
@@ -316,6 +321,7 @@ public class PlayerBehaviour : MonoBehaviour
     {
         // TO DO: play the animation for getting knocked back
         rb2d.velocity = new Vector2(_knockbackVelocity.x * (knockHamsterLeft ? -1 : 1), _knockbackVelocity.y);
+        Singleton<ScoreManager>.Instance.PlayerHit();
         inKnockback = true;
         canMove = false;
         StartCoroutine(InvincibilityFrames());


### PR DESCRIPTION
- Taking knockback decrements multiplier
- Fixed glitch with new ground detection code that often prevented you from moving anymore after getting knocked back
- Fixed errors in GameScene by putting two objects into the inspector
- Switched the moving platform's move regions to default layer so ground detection doesn't register them
- Fixed glitch with ground detection: you can now properly jump while standing in front of a low to the ground platform (tier 3)