### PR TITLE
Background move and fixes

### DIFF
--- a/Assets/PreFabs/Canvas.prefab
+++ b/Assets/PreFabs/Canvas.prefab
@@ -31,12 +31,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6722096070468154483}
+  m_Father: {fileID: 3554721410270378785}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 10, y: -10}
-  m_SizeDelta: {x: 200.31, y: 75.695}
+  m_SizeDelta: {x: 0, y: 75.695}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &235054579539346776
 CanvasRenderer:
@@ -174,7 +174,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1153995547050141456}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 1, y: 0, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -183,12 +183,12 @@ RectTransform:
   - {fileID: 3779908921611156516}
   - {fileID: 207760821799387844}
   - {fileID: 977374227447046380}
-  m_Father: {fileID: 8853139948967514778}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 775, y: 100}
+  m_Father: {fileID: 3554721410270378785}
+  m_LocalEulerAnglesHint: {x: 180, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -387.5, y: -29.43}
+  m_SizeDelta: {x: 775, y: 62.061}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &5162201314777123773
 CanvasRenderer:
@@ -211,15 +211,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 0.9523551, b: 0.63207537, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: a59c9af9d81841f438f24da95fff82d1, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -255,7 +255,7 @@ RectTransform:
   m_GameObject: {fileID: 1441574029439666447}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 0.54, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7953912905205294646}
@@ -286,7 +286,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.65882355, g: 0.3647059, b: 0.14901961, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -333,13 +333,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6722096070468154483}
+  m_Father: {fileID: 3554721410270378785}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 75.695}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 506.8, y: -18.349976}
+  m_SizeDelta: {x: 212.27, y: 75}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &3285880347412973099
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -439,70 +439,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &4349589961047379667
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6722096070468154483}
-  - component: {fileID: 7160216272672460817}
-  m_Layer: 5
-  m_Name: Score&MultiplierContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6722096070468154483
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4349589961047379667}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6529645051514947130}
-  - {fileID: 1420676282618325354}
-  m_Father: {fileID: 8853139948967514778}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 978.49, y: 102.5}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &7160216272672460817
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4349589961047379667}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 10
-    m_Right: 0
-    m_Top: 10
-    m_Bottom: 0
-  m_ChildAlignment: 0
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 1
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &5241205447402358468
 GameObject:
   m_ObjectHideFlags: 0
@@ -530,7 +466,7 @@ RectTransform:
   m_GameObject: {fileID: 5241205447402358468}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 0.54, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7953912905205294646}
@@ -561,7 +497,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.65882355, g: 0.3647059, b: 0.14901961, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -609,7 +545,9 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8853139948967514778}
+  - {fileID: 7953912905205294646}
+  - {fileID: 1420676282618325354}
+  - {fileID: 6529645051514947130}
   - {fileID: 5492181308831006530}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -681,43 +619,6 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!1 &6442703179871711225
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8853139948967514778}
-  m_Layer: 5
-  m_Name: Top Left UI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8853139948967514778
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6442703179871711225}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6722096070468154483}
-  - {fileID: 7953912905205294646}
-  m_Father: {fileID: 3554721410270378785}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 978.49, y: 179.3}
-  m_Pivot: {x: 0, y: 1}
 --- !u!1 &7398511030233435521
 GameObject:
   m_ObjectHideFlags: 0
@@ -745,7 +646,7 @@ RectTransform:
   m_GameObject: {fileID: 7398511030233435521}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 0.54, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7953912905205294646}
@@ -776,7 +677,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.65882355, g: 0.3647059, b: 0.14901961, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -828,7 +729,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -10, y: -10}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 113.137, y: 113.137}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &3826328629048108132
 CanvasRenderer:
@@ -895,7 +796,7 @@ RectTransform:
   m_GameObject: {fileID: 8821344116113022191}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.98, y: 0.5, z: 0.99}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7953912905205294646}
@@ -933,7 +834,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: f6588c94e6b29ce4bb64f7728a1f0518, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 298d09a47b6994e43a19b96e7e9b32e7, type: 3}
   m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -202,26 +202,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1420676282618325354, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3554721410270378785, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -305,34 +285,6 @@ PrefabInstance:
     - target: {fileID: 5321800515731768153, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
       propertyPath: m_Name
       value: Canvas
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200.31
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 6529645051514947130, guid: 8e4a59284b6bc904a9c51afa2fc5ce00, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1579,6 +1531,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1874505109}
   - component: {fileID: 1874505108}
+  - component: {fileID: 1874505110}
   m_Layer: 0
   m_Name: GameBG
   m_TagString: Untagged
@@ -1653,6 +1606,20 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1874505110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1874505107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5380091a50dd0be43ae8f3d549123ad4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  coyoteTime: 0.5
+  fallTime: 1.5
 --- !u!1001 &1893879966
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BackgroundBehavior.cs
+++ b/Assets/Scripts/BackgroundBehavior.cs
@@ -1,0 +1,64 @@
+/*****************************************************************************
+// File Name :         BackgroundBehavior.cs
+// Author :            Marissa Moser
+// Contributors:       
+// Creation Date :     03/05/2025
+//
+// Brief Description : Moves the background when a tier is swiped.
+*****************************************************************************/
+using System;
+using System.Collections;
+using UnityEngine;
+
+public class BackgroundBehavior : MonoBehaviour
+{
+    public static Action MoveBackgroundAction;
+    private Vector3 defaultPos;
+
+    [Tooltip("How long the tier should float for before falling")]
+    [SerializeField] private float coyoteTime;
+    [Tooltip("How long the tier should take to fall")]
+    [SerializeField] private float fallTime;
+
+void OnEnable()
+    {
+        MoveBackgroundAction += CallMoveBackgroundCoroutine;
+        defaultPos = transform.position;
+    }
+
+    /// <summary>
+    /// Called by the MoveBackground Action to start the coroutine that mves the 
+    /// baclground.
+    /// </summary>
+    private void CallMoveBackgroundCoroutine()
+    {
+        defaultPos += new Vector3(0, 20, 0);
+        StartCoroutine(MoveBackground());
+    }
+
+    void OnDisable()
+    {
+        MoveBackgroundAction -= CallMoveBackgroundCoroutine;
+    }
+
+    /// <summary>
+    /// Moves the background after coyote time has passed for as long as fall time is
+    /// set to.
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator MoveBackground()
+    {
+        yield return new WaitForSeconds(coyoteTime);
+
+        Vector3 startPos = transform.position;
+        Vector3 endPos = defaultPos;
+        float t = 0;
+        while (t <= 1.0f)
+        {
+            t += Time.deltaTime / fallTime;
+            transform.position = Vector3.Lerp(startPos, endPos, t);
+            yield return new WaitForFixedUpdate();
+        }
+        transform.position = endPos;
+    }
+}

--- a/Assets/Scripts/BackgroundBehavior.cs.meta
+++ b/Assets/Scripts/BackgroundBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5380091a50dd0be43ae8f3d549123ad4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tier Behaviors/Tier.cs
+++ b/Assets/Scripts/Tier Behaviors/Tier.cs
@@ -66,9 +66,11 @@ public class Tier : MonoBehaviour
         {
             Trapdoor.GetComponent<Trapdoor>().DisableDoor();
         }
+
+        BackgroundBehavior.MoveBackgroundAction?.Invoke();
     }
 
-   
+
     public IEnumerator SwipeCanceled(float timeRemaining)
     { 
         yield return new WaitForSeconds(timeRemaining);

--- a/Assets/Scripts/Tier Behaviors/TierManager.cs
+++ b/Assets/Scripts/Tier Behaviors/TierManager.cs
@@ -145,6 +145,8 @@ public class TierManager : Singleton<TierManager>
             canSwipe = false;
             print("last tier swiped");
         }
+
+        ScoreManager.Instance.LayerSwipeVitalityChange();
     }
 
     private void OnDisable()

--- a/Assets/Scripts/Tier Behaviors/TierManager.cs
+++ b/Assets/Scripts/Tier Behaviors/TierManager.cs
@@ -49,17 +49,6 @@ public class TierManager : Singleton<TierManager>
     }
 
     /// <summary>
-    /// Will be removed after testing is sufficient
-    /// </summary>
-    void Update()
-    {
-        if(Input.GetKeyDown(KeyCode.T))
-        {
-            //SwipeTierAction?.Invoke(tierCamShakeDuration);
-        }
-    }
-
-    /// <summary>
     /// function that returns true if the player is in the bottom tier.
     /// </summary>
     public bool IsInBottomTier()

--- a/Assets/Scripts/UIBehaviors/PauseMenuBehavior.cs
+++ b/Assets/Scripts/UIBehaviors/PauseMenuBehavior.cs
@@ -81,7 +81,8 @@ public class PauseMenuBehavior : MonoBehaviour
     private void ConfirmQuit(InputAction.CallbackContext context)
     {
         Time.timeScale = 1;
-        Application.Quit();
+        SceneManager.LoadScene(0);
+        //Application.Quit();
     }
 
     private void OnDisable()


### PR DESCRIPTION
completed changes in branch:
-moved multiplier bar to not block the player's view of the trapdoor and added some temp colors.
-pause menu quit button goes to the main menu instead of quitting the game.
-player's multiplier bar gets reset when their tier is swiped.
-kitchen background image moves with tiers getting swiped.

Game scene needed changes:
-revert all canvas prefab changes to fix the miltiplier text.
-add BackgroundBehavior script to the background image. Set fields in inspector Coyote time = 0.5 and Fall time = 1.5. You can play with these times, but I like these ones.