### PR TITLE
Fixing the Disappearing Platform

### DIFF
--- a/Assets/Scripts/Platforming types/DisapearingPlatforms.cs
+++ b/Assets/Scripts/Platforming types/DisapearingPlatforms.cs
@@ -11,6 +11,11 @@ using UnityEngine;
 
 public class DisapearingPlatforms : MonoBehaviour
 {
+    [Tooltip("True means the player has to touch the top for the platform to disappear")]
+    [SerializeField] private bool CoroutineStarted;
+    Rigidbody2D rb;
+
+
     private Vector3 defaultPosition;
     [SerializeField] private float disappearTime = 2f;
     [SerializeField] private float reappearTime = 5f;
@@ -33,17 +38,16 @@ public class DisapearingPlatforms : MonoBehaviour
         platformCollider = GetComponent<Collider2D>();
     }
 
-
-    /// <summary>
-    /// Checks if it is the player
-    /// </summary>
-    void OnCollisionEnter2D(Collision2D collision)
+    private void OnCollisionStay2D(Collision2D collision)
     {
-        PlayerBehaviour playerBehaviour = collision.gameObject.GetComponent<PlayerBehaviour>();
-
-        if (playerBehaviour != null)
+        if (!CoroutineStarted && collision.collider.TryGetComponent<PlayerBehaviour>(out PlayerBehaviour pb))
         {
-            StartCoroutine(DisappearAndReappear());
+           if (pb.PlayerPlatformCheck())
+           {
+                StartCoroutine(DisappearAndReappear());
+                CoroutineStarted = true;
+           }
+            
         }
     }
 
@@ -78,5 +82,7 @@ public class DisapearingPlatforms : MonoBehaviour
         spriteRenderer.enabled = true;
         if (_shadow != null) _shadow.enabled = true;
         platformCollider.enabled = true;
+
+        CoroutineStarted = false;
     }
 }

--- a/Assets/Scripts/PlayerScripts/PlayerBehaviour.cs
+++ b/Assets/Scripts/PlayerScripts/PlayerBehaviour.cs
@@ -165,7 +165,7 @@ public class PlayerBehaviour : MonoBehaviour
     /// Checks if the player is grounded to see if they can jump
     /// </summary>
     /// <returns></returns>
-    private bool CanJump()
+    public bool CanJump()
     {
         var hit = Physics2D.BoxCast(hitbox.bounds.center, hitbox.bounds.size * .95f, 0, Vector2.down, 0.1f, ground);
         if (hit.collider != null)
@@ -176,6 +176,11 @@ public class PlayerBehaviour : MonoBehaviour
             return (hitbox.bounds.min.y > hit.collider.bounds.max.y - 0.1f) || (Mathf.Abs(rb2d.velocity.y) < 0.01f);
         }
         return false;
+    }
+    
+    public bool PlayerPlatformCheck()
+    {
+        return rb2d.velocity.y <= 0.01f;
     }
 
     /// <summary>


### PR DESCRIPTION
The platforms no longer trigger when just touching them. You have to be on top of the platform. 